### PR TITLE
(pkgs) Fix the display of the command executed

### DIFF
--- a/web/modules/pkgs/includes/actions/actionprocessscriptfile.php
+++ b/web/modules/pkgs/includes/actions/actionprocessscriptfile.php
@@ -92,6 +92,7 @@ extract($_POST);
         <tr>
             <th>Script</th>
             <th>
+              <?php $script = (base64_decode($script, true) != false) ? $script = base64_decode($script) : $script; ?>
               <textarea name="script" cols="5" rows="5"><?php echo $script ;?></textarea>
             </th>
         </tr>


### PR DESCRIPTION
In pkgs the action "execute script" displayed systematically the command in base64. Now the command is tested before displaying.