### PR TITLE
(deployement) Fix/change deployments status.

### DIFF
--- a/services/contrib/Makefile.am
+++ b/services/contrib/Makefile.am
@@ -254,6 +254,7 @@ nobase_dist_contrib_DATA = dyngroup/sql/clean-db.sql \
 	xmppmaster/sql/schema-064.sql \
 	xmppmaster/sql/schema-065.sql \
 	xmppmaster/sql/schema-066.sql \
+	xmppmaster/sql/schema-070.sql \
 	kiosk/sql/schema-001.sql \
 	kiosk/sql/schema-002.sql \
 	kiosk/sql/schema-003.sql \

--- a/services/contrib/xmppmaster/sql/schema-070.sql
+++ b/services/contrib/xmppmaster/sql/schema-070.sql
@@ -1,0 +1,497 @@
+--
+-- (c) 2021 Siveo, http://www.siveo.net/
+--
+--
+-- This file is part of Pulse 2, http://www.siveo.net/
+--
+-- Pulse 2 is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+--
+-- Pulse 2 is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with Pulse 2; if not, write to the Free Software
+-- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+-- MA 02110-1301, USA.
+
+-- ----------------------------------------------------------------------
+-- Database xmppmaster
+-- ----------------------------------------------------------------------
+
+START TRANSACTION;
+
+USE `xmppmaster`;
+DROP function IF EXISTS `fs_jidusertrue`;
+
+USE `xmppmaster`;
+DROP function IF EXISTS `xmppmaster`.`fs_jidusertrue`;
+
+DELIMITER $$
+USE `xmppmaster`$$
+CREATE FUNCTION `fs_jidusertrue`(jid char(255)) RETURNS char(255) CHARSET utf8
+BEGIN
+RETURN  substring_index(substring_index(jid, '@', 1), '.', 1);
+END$$
+
+DELIMITER ;
+
+
+-- ----------------------------------------------------------------------
+-- index
+-- ----------------------------------------------------------------------
+ALTER TABLE `xmppmaster`.`deploy`
+ADD INDEX `ind_title` (`title` ASC) ;
+
+
+
+-- ----------------------------------------------------------------------
+-- mmc_delete_deploy_session_id stored procedure
+-- -----------------------------------------------------------------------
+USE `xmppmaster`;
+DROP procedure IF EXISTS `mmc_delete_deploy_session_id`;
+
+USE `xmppmaster`;
+DROP procedure IF EXISTS `xmppmaster`.`mmc_delete_deploy_session_id`;
+;
+
+DELIMITER $$
+USE `xmppmaster`$$
+CREATE PROCEDURE `mmc_delete_deploy_session_id`(IN IN_sessid VARCHAR(255))
+BEGIN
+-- cette procedure supprime les deployement dans la table log et deploysuivant la session passe.
+-- delete log information
+DELETE FROM `xmppmaster`.`logs` WHERE (`sessionname` like IN_sessid);
+DELETE FROM `xmppmaster`.`deploy` WHERE (`sessionid` like IN_sessid);
+END$$
+
+DELIMITER ;
+;
+
+USE `xmppmaster`;
+DROP procedure IF EXISTS `xmppmaster`.`mmc_delete_blocked_convergence`;
+
+DELIMITER $$
+USE `xmppmaster`$$
+CREATE PROCEDURE `mmc_delete_blocked_convergence`()
+BEGIN
+-- Cette procedure supprime de la table delpoy et de la table log
+-- les deployements appartenant a une 1 Convergence restant bloque
+-- les deployement supprimer ne sont pas relance.
+-- les deployements seront relancé par la convergence planifier.
+
+DECLARE finished INTEGER DEFAULT 0;
+DECLARE session_string varchar(100) DEFAULT "";
+DECLARE machine_name varchar(50) DEFAULT "";
+DECLARE ars_name varchar(50) DEFAULT "";
+DECLARE title_deploy varchar(100) DEFAULT "";
+DECLARE history_log_msg varchar (1024) default "";
+DECLARE message_log varchar (1024) default "";
+DECLARE limit_deploy integer default 10000000;
+DECLARE nombreselect INTEGER DEFAULT 0;
+DECLARE cursor_session_reload CURSOR FOR
+SELECT DISTINCT
+    `xmppmaster`.`deploy`.sessionid,
+	`xmppmaster`.`deploy`.title,
+	fs_jidusertrue( `xmppmaster`.`deploy`.jidmachine),
+	fs_jidusertrue( `xmppmaster`.`deploy`.jid_relay),
+	`xmppmaster`.`logs`.text
+FROM
+    xmppmaster.deploy
+        JOIN
+    logs ON logs.sessionname = deploy.sessionid
+WHERE
+    deploy.title  like "Convergence%"
+    AND deploy.state = 'DEPLOYMENT START'
+	AND (NOW() BETWEEN deploy.startcmd AND deploy.endcmd)
+	AND sessionname = deploy.sessionid
+	AND ((logs.text REGEXP '^First WOL|^Second WOL|^Third WOL|.*Trying to continue deployment|Starting deployment$|^Key successfully present'
+	AND logs.date < DATE_ADD(NOW(), INTERVAL - 600 SECOND))
+	OR (logs.text REGEXP '^Client generated transfer command is'
+	AND logs.date < DATE_ADD(NOW(), INTERVAL - 1 DAY)))
+GROUP BY deploy.sessionid ;
+-- declare NOT FOUND handler
+DECLARE CONTINUE HANDLER
+	FOR NOT FOUND SET finished = 1;
+# pour chaque result appeler reload deploy
+OPEN cursor_session_reload;
+nextsessionid: LOOP
+	FETCH cursor_session_reload INTO session_string, title_deploy,machine_name, ars_name,history_log_msg;
+	IF finished = 1 THEN LEAVE nextsessionid;
+	END IF;
+	call `mmc_delete_deploy_session_id`(session_string);
+	-- create message log
+	SELECT CONCAT("Delete locked deploy   [", title_deploy, "] previous session  ", session_string, " on machine ", machine_name , " [blocked on message :", history_log_msg, " ]")
+	INTO message_log;
+	INSERT INTO `xmppmaster`.`logs` (`type`, `module`, `text`, `fromuser`, `touser`, `action`, `sessionname`, `priority`, `who`) 
+	VALUES ('deploy', 'Deployment | Restart | Notify', message_log, 'mysql', 'admin', 'xmpplog', 'command...', '-1', 'mysql');
+END LOOP nextsessionid;
+CLOSE cursor_session_reload;
+END$$
+
+DELIMITER ;
+
+
+-- ----------------------------------------------------------------------
+-- mmc_restart_deploy_sessionid stored procedure
+-- -----------------------------------------------------------------------
+USE `xmppmaster`;
+DROP procedure IF EXISTS `mmc_restart_deploy_sessionid`;
+
+USE `xmppmaster`;
+DROP procedure IF EXISTS `xmppmaster`.`mmc_restart_deploy_sessionid`;
+
+DELIMITER $$
+USE `xmppmaster`$$
+CREATE PROCEDURE `mmc_restart_deploy_sessionid`(IN IN_sessid VARCHAR(255), in force_redeploy integer, in rechedule_deploy integer)
+BEGIN
+-- parameters
+-- IN_sessid session id deployement
+-- force_redeploy = 1 do not consider ignored status (variable: ignorestatus)
+-- rechedule_deploy = 1 Replan the deploiements betwenn not and 1 day
+-- TODO: Update the list on which we forbid redeploy.
+SET @ignorestatus0 = "DEPLOYMENT SUCCESS";
+SET @ignorestatus1 = "WAITING MACHINE ONLINE";
+set @total = 0;
+ IF force_redeploy > 0 THEN
+	set @cmd = (select command from  xmppmaster.deploy where sessionid like IN_sessid limit 1);
+ else
+     set @cmd = (select command from  xmppmaster.deploy where sessionid like IN_sessid and state not in (@ignorestatus0,@ignorestatus1) limit 1);
+ END IF;
+ SELECT  COUNT(*) from    xmppmaster.deploy  where sessionid like IN_sessid into @total;
+if @total != 0 THEN
+	set @grp = (select group_uuid from  xmppmaster.deploy where sessionid like IN_sessid limit 1);
+    set @name_mach = (select FS_JIDUSERTRUE(host) as host from  xmppmaster.deploy where sessionid like IN_sessid limit 1);
+    set @fk_commands_on_host = (select id from msc.commands_on_host where FS_JIDUSERTRUE(host)=@name_mach and fk_commands = @cmd limit 1);
+    DELETE FROM `xmppmaster`.`logs` WHERE (`sessionname` like IN_sessid);
+	DELETE FROM `xmppmaster`.`deploy` WHERE (`sessionid` like IN_sessid);
+    IF rechedule_deploy > 0 THEN
+	   -- sinon recreation des deployement avec meme planification.
+	   -- rechedule_deploy is 1 on s assure que le deployement soit rejoue quelque soit sa planification.
+	   UPDATE `msc`.`commands` SET `end_date` = now() + INTERVAL 1 DAY WHERE (`id` =  @cmd); -- and  NOW() > end_date;
+	END IF;
+    UPDATE `msc`.`phase` SET `state` = 'ready' WHERE (`msc`.`phase`.`fk_commands_on_host` = @fk_commands_on_host );
+ END IF;
+END$$
+
+DELIMITER ;
+
+-- ----------------------------------------------------------------------
+-- mmc_restart_deploy_cmdid stored procedure
+-- -----------------------------------------------------------------------
+USE `xmppmaster`;
+DROP procedure IF EXISTS `mmc_restart_deploy_cmdid`;
+
+USE `xmppmaster`;
+DROP procedure IF EXISTS `xmppmaster`.`mmc_restart_deploy_cmdid`;
+
+DELIMITER $$
+USE `xmppmaster`$$
+CREATE PROCEDURE `mmc_restart_deploy_cmdid`(in cmd_id integer, in force_redeploy integer, in rechedule_deploy integer)
+BEGIN
+set @total = 0;
+-- TODO: Update the list on which we forbid redeploy.
+SET @ignorestatus = "'DEPLOYMENT SUCCESS','WAITING MACHINE ONLINE'";
+
+-- parameters
+-- cmd_id command the msc id of the group or the individual machine.
+-- force_redeploy = 1 do not consider ignored status (variable: ignorestatus)
+-- rechedule_deploy = 1 Replan the deploiements betwenn not and 1 day
+
+IF force_redeploy > 0 THEN
+	 SET @s = CONCAT("CREATE TEMPORARY TABLE list_sessio_id SELECT FS_JIDUSERTRUE(host) as host, sessionid FROM xmppmaster.deploy where command = " , cmd_id);
+else
+   SET @s = CONCAT("CREATE TEMPORARY TABLE list_sessio_id SELECT  FS_JIDUSERTRUE(host) as host,sessionid FROM xmppmaster.deploy where command = " ,cmd_id, " and state not in (", @ignorestatus,")" );
+ END IF;
+PREPARE stmt FROM @s;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+ SELECT
+    COUNT(*)
+ FROM
+   list_sessio_id into @total;
+  if @total != 0 THEN
+	-- temporary table list_sessio_id content session_id for restart deploiement
+	-- DELETE FROM `xmppmaster`.`logs` WHERE	`sessionname` IN (SELECT sessionid FROM list_sessio_id);
+	-- the deploiements does not exit anymore.
+	 DELETE FROM `xmppmaster`.`deploy` WHERE `sessionid` IN (SELECT sessionid	FROM list_sessio_id);
+
+	 IF rechedule_deploy > 0 THEN
+       -- If not, we create the deploiements with the same date/hour.
+       -- rechedule_deploy is 1:  we make sure that that the deploiement is replayed whenever it is planned.
+	    UPDATE `msc`.`commands` SET `end_date` = now() + INTERVAL 1 DAY WHERE (`id` = cmd_id); -- and  NOW() > end_date;
+	 END IF;
+
+    -- we calculate all the commands_on_host id fields and we list the selected sessions.
+	CREATE TEMPORARY TABLE `commands_on_host_id`  SELECT id FROM msc.commands_on_host
+       JOIN list_sessio_id ON list_sessio_id.host = FS_JIDUSERTRUE(msc.commands_on_host.host)
+	 WHERE msc.commands_on_host.fk_commands = cmd_id;
+
+	 UPDATE `msc`.`phase` SET `state` = 'ready' WHERE  `msc`.`phase`.`fk_commands_on_host` IN (select id from `commands_on_host_id` );
+  END IF;
+drop table IF EXISTS list_sessio_id;
+drop table IF EXISTS commands_on_host_id;
+END$$
+
+DELIMITER ;
+
+
+-- ----------------------------------------------------------------------
+-- stored procedure  mmc_restart_blocked_deployments
+-- -----------------------------------------------------------------------
+USE `xmppmaster`;
+DROP procedure IF EXISTS `mmc_restart_blocked_deployments`;
+
+USE `xmppmaster`;
+DROP procedure IF EXISTS `xmppmaster`.`mmc_restart_blocked_deployments`;
+
+DELIMITER $$
+USE `xmppmaster`$$
+CREATE PROCEDURE `mmc_restart_blocked_deployments`( in nombre_reload integer)
+BEGIN
+DECLARE finished INTEGER DEFAULT 0;
+DECLARE session_string varchar(100) DEFAULT "";
+DECLARE machine_name varchar(50) DEFAULT "";
+DECLARE ars_name varchar(50) DEFAULT "";
+DECLARE title_deploy varchar(100) DEFAULT "";
+DECLARE history_log_msg varchar (1024) default "";
+DECLARE message_log varchar (1024) default "";
+DECLARE limit_deploy integer default 10000000;
+DECLARE nombreselect INTEGER DEFAULT 0;
+DECLARE cursor_session_reload CURSOR FOR
+-- deploy list fields :'id,title,jidmachine,jid_relay,pathpackage,state,sessionid,start,startcmd,endcmd,inventoryuuid,host,user,command,group_uuid,login,macadress,syncthing,result,subdep'
+-- logs list fields :' id,date,type,module,text,fromuser,touser,action,sessionname,how,why,priority,who'
+
+SELECT DISTINCT
+    `xmppmaster`.`deploy`.sessionid,
+	`xmppmaster`.`deploy`.title,
+    fs_jidusertrue( `xmppmaster`.`deploy`.jidmachine),
+    fs_jidusertrue( `xmppmaster`.`deploy`.jid_relay),
+    `xmppmaster`.`logs`.text
+FROM
+    xmppmaster.deploy
+        JOIN
+    logs ON logs.sessionname = deploy.sessionid
+WHERE
+    deploy.title  NOT like "Convergence%"
+	AND deploy.state = 'DEPLOYMENT START'
+	AND (NOW() BETWEEN deploy.startcmd AND deploy.endcmd)
+	AND sessionname = deploy.sessionid
+	AND ((logs.text REGEXP '^First WOL|^Second WOL|^Third WOL|.*Trying to continue deployment|Starting deployment$|^Key successfully present'
+	AND logs.date < DATE_ADD(NOW(), INTERVAL - 600 SECOND))
+	OR (logs.text REGEXP '^Client generated transfer command is'
+	AND logs.date < DATE_ADD(NOW(), INTERVAL - 1 DAY)))
+GROUP BY deploy.sessionid limit nombre_reload;
+-- declare NOT FOUND handler
+DECLARE CONTINUE HANDLER
+    FOR NOT FOUND SET finished = 1;
+if  nombre_reload != -1 then
+    set limit_deploy = nombre_reload;
+end if;
+# pour chaque result appeler reload deploy
+OPEN cursor_session_reload;
+nextsessionid: LOOP
+	FETCH cursor_session_reload INTO session_string,title_deploy,machine_name,ars_name,history_log_msg;
+	IF finished = 1 THEN
+		LEAVE nextsessionid;
+	END IF;
+	-- count
+	set nombreselect = nombreselect + 1;
+	-- call reload deployement
+	call `mmc_restart_deploy_sessionid`(session_string, 1, 0);
+	-- create message log
+	SELECT CONCAT("Restarting deployment [", title_deploy, "] previous session  ", session_string, " on machine ", machine_name , " via relay ", ars_name, " [blocked on message :", history_log_msg, " ]") 
+	INTO  message_log;
+	INSERT INTO `xmppmaster`.`logs` (`type`, `module`, `text`, `fromuser`, `touser`, `action`, `sessionname`, `priority`, `who`)
+	VALUES ('deploy', 'Deployment | Restart | Notify', message_log, 'mysql', 'admin', 'xmpplog', 'command...', '-1', 'mysql');
+END LOOP nextsessionid;
+CLOSE cursor_session_reload;
+select nombreselect;
+END$$
+
+DELIMITER ;
+
+-- ----------------------------------------------------------------------
+-- stored procedure  mmc_delete_blocked_convergence_transfer_error
+-- Delete deployments blocked in states ERROR TRANSFER FAILED and ERROR TRANSFER FAILED 
+-- coming from a convergence
+-- -----------------------------------------------------------------------
+USE `xmppmaster`;
+DROP procedure IF EXISTS `mmc_delete_blocked_convergence_transfer_error`;
+
+USE `xmppmaster`;
+DROP procedure IF EXISTS `xmppmaster`.`mmc_delete_blocked_convergence_transfer_error`;
+
+DELIMITER $$
+USE `xmppmaster`$$
+CREATE  PROCEDURE `mmc_delete_blocked_convergence_transfer_error`()
+BEGIN
+DECLARE finished INTEGER DEFAULT 0;
+DECLARE session_string varchar(100) DEFAULT "";
+DECLARE machine_name varchar(50) DEFAULT "";
+DECLARE ars_name varchar(50) DEFAULT "";
+DECLARE title_deploy varchar(100) DEFAULT "";
+DECLARE history_log_msg varchar (1024) default "";
+DECLARE date_log timestamp default "";
+DECLARE id_log varchar (12) default "";
+DECLARE message_log varchar (1024) default "";
+DECLARE limit_deploy integer default 10000000;
+DECLARE nombreselect INTEGER DEFAULT 0;
+DECLARE cursor_session_reload CURSOR FOR
+-- deploy list fields :'id,title,jidmachine,jid_relay,pathpackage,state,sessionid,start,startcmd,endcmd,inventoryuuid,host,user,command,group_uuid,login,macadress,syncthing,result,subdep'
+-- logs list fields :' id,date,type,module,text,fromuser,touser,action,sessionname,how,why,priority,who'
+-- delete deployement en etat ERROR TRANSFER FAILED et ERROR TRANSFER FAILED bloquee
+-- issu d une convergence
+SELECT DISTINCT
+	`xmppmaster`.`deploy`.sessionid,
+	`xmppmaster`.`deploy`.title,
+	fs_jidusertrue( `xmppmaster`.`deploy`.jidmachine),
+	fs_jidusertrue( `xmppmaster`.`deploy`.jid_relay),
+	newtablelog.text,
+	newtablelog.date,
+	newtablelog.id
+FROM
+    xmppmaster.deploy
+        JOIN
+    (SELECT
+        aaa.id, aaa.text, aaa.sessionname, aaa.date
+    FROM
+        logs aaa
+    INNER JOIN (SELECT
+        *, MAX(id) AS ddddd
+    FROM
+        logs
+    GROUP BY sessionname) AS bbb ON aaa.sessionname = bbb.sessionname
+        AND aaa.id = bbb.ddddd) newtablelog ON newtablelog.sessionname = deploy.sessionid
+WHERE
+    deploy.state REGEXP 'TRANSFER FAILED$'
+	AND deploy.title LIKE 'Convergence%'
+	AND (NOW() BETWEEN deploy.startcmd AND deploy.endcmd)
+	AND (newtablelog.text NOT REGEXP '^.*ABORT DEPLOYMENT CANCELLED BY USER.*$'
+	AND newtablelog.date < DATE_ADD(NOW(), INTERVAL - 1 HOUR));
+-- declare NOT FOUND handler
+DECLARE CONTINUE HANDLER
+    FOR NOT FOUND SET finished = 1;
+
+OPEN cursor_session_reload;
+nextsessionid: LOOP
+	FETCH cursor_session_reload INTO session_string,title_deploy,machine_name,ars_name,history_log_msg, date_log, id_log  ;
+	IF finished = 1 THEN LEAVE nextsessionid;
+	END IF;
+	-- count
+	set nombreselect = nombreselect + 1;
+	-- call reload deployement
+    call `mmc_delete_deploy_session_id`(session_string);
+	-- create message log
+	SELECT CONCAT('Delete locked deploy [', title_deploy, '] previous session  ', session_string, ' on machine ', machine_name, ' via relay ', ars_name, ' [blocked on message :', history_log_msg, ' ]')
+	INTO message_log;
+	INSERT INTO `xmppmaster`.`logs` (`type`, `module`, `text`, `fromuser`, `touser`, `action`, `sessionname`, `priority`, `who`)
+	VALUES ('deploy', 'Deployment | Restart | Notify', message_log, 'mysql', 'admin', 'xmpplog', 'command...', '-1', 'mysql');
+END LOOP nextsessionid;
+CLOSE cursor_session_reload;
+END$$
+
+DELIMITER ;
+
+-- ----------------------------------------------------------------------
+-- stored procedure  mmc_restart_blocked_deployments_transfer_error
+-- Selects deployments in states ERROR TRANSFER FAILED and ERROR TRANSFER FAILED
+-- Remark: Deployments coming from convergence are ignored
+-- -----------------------------------------------------------------------
+USE `xmppmaster`;
+DROP procedure IF EXISTS `mmc_restart_blocked_deployments_transfer_error`;
+
+USE `xmppmaster`;
+DROP procedure IF EXISTS `xmppmaster`.`mmc_restart_blocked_deployments_transfer_error`;
+
+DELIMITER $$
+USE `xmppmaster`$$
+CREATE PROCEDURE `mmc_restart_blocked_deployments_transfer_error`(in nombre_reload integer)
+BEGIN
+DECLARE finished INTEGER DEFAULT 0;
+DECLARE session_string varchar(100) DEFAULT "";
+DECLARE machine_name varchar(50) DEFAULT "";
+DECLARE ars_name varchar(50) DEFAULT "";
+DECLARE title_deploy varchar(100) DEFAULT "";
+DECLARE history_log_msg varchar (1024) default "";
+DECLARE date_log timestamp default "";
+DECLARE id_log varchar (12) default "";
+DECLARE message_log varchar (1024) default "";
+DECLARE limit_deploy integer default 10000000;
+DECLARE nombreselect INTEGER DEFAULT 0;
+DECLARE cursor_session_reload CURSOR FOR
+-- deploy list fields :'id,title,jidmachine,jid_relay,pathpackage,state,sessionid,start,startcmd,endcmd,inventoryuuid,host,user,command,group_uuid,login,macadress,syncthing,result,subdep'
+-- logs list fields :' id,date,type,module,text,fromuser,touser,action,sessionname,how,why,priority,who'
+-- selectionne n deploiement bloque sur les etat  ERROR TRANSFER FAILED et ERROR TRANSFER FAILED
+-- remarque les deploiements issus de convergence sont ignore
+     
+SELECT DISTINCT
+	`xmppmaster`.`deploy`.sessionid,
+	`xmppmaster`.`deploy`.title,
+	fs_jidusertrue( `xmppmaster`.`deploy`.jidmachine),
+	fs_jidusertrue( `xmppmaster`.`deploy`.jid_relay),
+	newtablelog.text,
+	newtablelog.date,
+	newtablelog.id
+FROM
+    xmppmaster.deploy
+        JOIN
+    (SELECT 
+        aaa.id, aaa.text, aaa.sessionname, aaa.date
+    FROM
+        logs aaa
+    INNER JOIN (SELECT 
+        *, MAX(id) AS ddddd
+    FROM
+        logs
+    GROUP BY sessionname) AS bbb ON aaa.sessionname = bbb.sessionname
+        AND aaa.id = bbb.ddddd) newtablelog ON newtablelog.sessionname = deploy.sessionid
+WHERE
+    deploy.state REGEXP 'TRANSFER FAILED$'
+	AND deploy.title NOT REGEXP '^Convergence'
+	AND (NOW() BETWEEN deploy.startcmd AND deploy.endcmd)
+	AND (newtablelog.text NOT REGEXP '^.*ABORT DEPLOYMENT CANCELLED BY USER.*$'
+	AND newtablelog.date < DATE_ADD(NOW(), INTERVAL - 600 SECOND))
+LIMIT nombre_reload;
+-- declare NOT FOUND handler
+DECLARE CONTINUE HANDLER
+    FOR NOT FOUND SET finished = 1;
+call  mmc_delete_blocked_convergence_transfer_error ();
+if  nombre_reload != -1 then
+    set limit_deploy = nombre_reload;
+end if;
+
+OPEN cursor_session_reload;
+nextsessionid: LOOP
+	FETCH cursor_session_reload INTO session_string,title_deploy,machine_name,ars_name,history_log_msg, date_log, id_log  ;
+	IF finished = 1 THEN LEAVE nextsessionid;
+	END IF;
+	-- count
+	set nombreselect = nombreselect + 1;
+	-- call reload deployement
+	call `mmc_restart_deploy_sessionid`(session_string, 1, 0);
+	-- create message log
+	SELECT CONCAT('Restarting deployment [', title_deploy, '] previous session  ', session_string, ' on machine ', machine_name, ' via relay ', ars_name, ' [blocked on message :', history_log_msg, ' ]') 
+	INTO message_log;
+	INSERT INTO `xmppmaster`.`logs` (`type`, `module`, `text`, `fromuser`, `touser`, `action`, `sessionname`, `priority`, `who`)
+	VALUES ('deploy', 'Deployment | Restart | Notify', message_log, 'mysql', 'admin', 'xmpplog', 'command...', '-1', 'mysql');
+END LOOP nextsessionid;
+CLOSE cursor_session_reload;
+SELECT nombreselect;
+END$$
+
+DELIMITER ;
+
+
+
+-- ----------------------------------------------------------------------
+-- Database version
+-- ----------------------------------------------------------------------
+UPDATE version SET Number = 70;
+
+COMMIT;

--- a/services/mmc/plugins/xmppmaster/master/agentmaster.py
+++ b/services/mmc/plugins/xmppmaster/master/agentmaster.py
@@ -505,11 +505,11 @@ class MUCBot(sleekxmpp.ClientXMPP):
             fichier.close()
             self.mesure = mesure
             print "______________________________"
-    def sendwol(self, macadress, hostnamemachine = ""):
+    def sendwol(self, macadress, machine_hostname=""):
         listmacadress = macadress.split("||")
         for macadressdata in listmacadress:
             if macadressdata != "":
-                logging.debug("wakeonlan machine  [Machine : %s]" % hostnamemachine)
+                logging.debug("wakeonlan machine  [Machine : %s]" % machine_hostname)
                 self.callpluginmasterfrommmc('wakeonlan', {'macadress': macadressdata})
 
     def _chunklist(self, listseq, nb = 5000):
@@ -544,8 +544,8 @@ class MUCBot(sleekxmpp.ClientXMPP):
             # machine ecart temps de deploiement terminer met status a ABORT ON TIMEOUT
             result = XmppMasterDatabase().Timeouterrordeploy()
             for machine in result:
-                hostnamemachine=machine['jidmachine'].split('@')[0][:-4]
-                msglog.append("<span class='log_err'>Deployment timed out on machine %s</span>"%hostnamemachine)
+                machine_hostname=machine['jidmachine'].split('@')[0][:-4]
+                msglog.append("<span class='log_err'>Deployment timed out on machine %s</span>"%machine_hostname)
                 msglog.append("<span class='log_err'>Machine is no longer available</span>")
             for logmsg in msglog:
                 self.xmpplog(logmsg,
@@ -557,20 +557,27 @@ class MUCBot(sleekxmpp.ClientXMPP):
                             module="Deployment | Start | Creation",
                             date=None,
                             fromuser=machine['login'])
-            msglog=[]
-            #########################################################################
+
+            # We change de status of the machine currently in a deploy but offline.
+            # We put them back in the queue
+            XmppMasterDatabase().update_status_waiting_for_machine_off_in_state_deploy_start()
+
+
+            # We select the machines in a deploiement stalled for more than 60 seconds.
+            XmppMasterDatabase().update_status_waiting_for_deploy_on_machine_restart_or_stop()
+
+            msglog = []
             machines_scheduled_deploy = XmppMasterDatabase().search_machines_from_state("DEPLOY TASK SCHEDULED")
             for machine in machines_scheduled_deploy:
-                ##datetime_startcmd = datetime.strptime(machine['startcmd'], '%Y-%m-%d %H:%M:%S')
-                ##datetime_endcmd = datetime.strptime(machine['startcmd'], '%Y-%m-%d %H:%M:%S')
                 UUID = machine['inventoryuuid']
 
                 resultpresence = XmppMasterDatabase().getPresenceExistuuids(UUID)
                 if resultpresence[UUID][1] == 0:
-                    # la machine n'est plus dans la table machine
-                    ### voir le message a afficher.
-                    # cas on 1 deployement est cheduler.
-                    # et la machine n'existe plus. soit son uuid GLPI a changer, ou elle a ete suprimer. la machine n'existe plus.
+                    # The machine is not on the machine table anymore
+                    #  voir le message a afficher.
+                    # This can happen when the deployment is scheduled but
+                    # -1- The UUID changed
+                    # -2- The machine has been removed from the machine table.
                     msglog.append("<span class='log_err'>Machine %s disappeared "\
                         "during deployment. GLPI ID: %s</span>"%(machine['jidmachine'], UUID))
                     XmppMasterDatabase().update_state_deploy(machine['id'], "ABORT MACHINE DISAPPEARED")
@@ -580,118 +587,115 @@ class MUCBot(sleekxmpp.ClientXMPP):
                     XmppMasterDatabase().update_state_deploy(machine['id'], "WOL 3")
             for logmsg in msglog:
                 self.xmpplog(logmsg,
-                            type='deploy',
-                            sessionname=machine['sessionid'],
-                            priority=-1,
-                            action="xmpplog",
-                            why=self.boundjid.bare,
-                            module="Deployment | Start | Creation",
-                            date=None,
-                            fromuser=machine['login'])
-            msglog=[]
-            ###########################################################################
+                             type='deploy',
+                             sessionname=machine['sessionid'],
+                             priority=-1,
+                             action="xmpplog",
+                             why=self.boundjid.bare,
+                             module="Deployment | Start | Creation",
+                             date=None,
+                             fromuser=machine['login'])
+            # Plan with blocked deployments again
+            XmppMasterDatabase().restart_blocked_deployments()
+
+            msglog = []
             machines_wol3 = XmppMasterDatabase().search_machines_from_state("WOL 3")
             for machine in machines_wol3:
                 XmppMasterDatabase().update_state_deploy(machine['id'], "WAITING MACHINE ONLINE")
-                hostnamemachine=machine['jidmachine'].split('@')[0][:-4]
-                msglog.append("Waiting for machine %s to be online"%hostnamemachine)
+                machine_hostname = machine['jidmachine'].split('@')[0][:-4]
+                msglog.append("Waiting for machine %s to be online" % machine_hostname)
             for logmsg in msglog:
                 self.xmpplog(logmsg,
-                            type='deploy',
-                            sessionname=machine['sessionid'],
-                            priority=-1,
-                            action="xmpplog",
-                            why=self.boundjid.bare,
-                            module="Deployment | Start | Creation",
-                            date=None,
-                            fromuser=machine['login'])
+                             type='deploy',
+                             sessionname=machine['sessionid'],
+                             priority=-1,
+                             action="xmpplog",
+                             why=self.boundjid.bare,
+                             module="Deployment | Start | Creation",
+                             date=None,
+                             fromuser=machine['login'])
             msglog=[]
-            ###########################################################################
             machines_wol2 = XmppMasterDatabase().search_machines_from_state("WOL 2")
             for machine in machines_wol2:
                 if XmppMasterDatabase().getPresenceuuid(machine['inventoryuuid']):
-                    # recu presence machine.
+                    # The machine is online
                     XmppMasterDatabase().update_state_deploy(machine['id'], "WAITING MACHINE ONLINE")
                     continue
                 XmppMasterDatabase().update_state_deploy(machine['id'], "WOL 3")
-                hostnamemachine=machine['jidmachine'].split('@')[0][:-4]
+                machine_hostname = machine['jidmachine'].split('@')[0][:-4]
                 self._addsetwol(wol_set, machine['macadress'])
-                msglog.append("Third WOL sent to machine %s"%hostnamemachine)
+                msglog.append("Third WOL sent to machine %s" % machine_hostname)
             for logmsg in msglog:
                 self.xmpplog(logmsg,
-                            type='deploy',
-                            sessionname=machine['sessionid'],
-                            priority=-1,
-                            action="xmpplog",
-                            why=self.boundjid.bare,
-                            module="Deployment | Start | Creation",
-                            date=None,
-                            fromuser=machine['login'])
-            msglog=[]
-            ###########################################################################
+                             type='deploy',
+                             sessionname=machine['sessionid'],
+                             priority=-1,
+                             action="xmpplog",
+                             why=self.boundjid.bare,
+                             module="Deployment | Start | Creation",
+                             date=None,
+                             fromuser=machine['login'])
+            msglog = []
             machines_wol1 = XmppMasterDatabase().search_machines_from_state("WOL 1")
             for machine in machines_wol1:
                 if XmppMasterDatabase().getPresenceuuid(machine['inventoryuuid']):
-                    # recu presence machine.
+                    # The machine is online
                     XmppMasterDatabase().update_state_deploy(machine['id'], "WAITING MACHINE ONLINE")
                     continue
                 XmppMasterDatabase().update_state_deploy(machine['id'], "WOL 2")
-                hostnamemachine=machine['jidmachine'].split('@')[0][:-4]
+                machine_hostname=machine['jidmachine'].split('@')[0][:-4]
                 self._addsetwol(wol_set, machine['macadress'])
-                #self.sendwol(machine['macadress'], hostnamemachine)
 
-                msglog.append("Second WOL sent to machine %s"%hostnamemachine)
+                msglog.append("Second WOL sent to machine %s" % machine_hostname)
             for logmsg in msglog:
                 self.xmpplog(logmsg,
-                            type='deploy',
-                            sessionname=machine['sessionid'],
-                            priority=-1,
-                            action="xmpplog",
-                            why=self.boundjid.bare,
-                            module="Deployment | Start | Creation",
-                            date=None,
-                            fromuser=machine['login'])
-            msglog=[]
-            ###########################################################################
-            #relance machine off_line to on_line
-            machines_waitting_online = XmppMasterDatabase().search_machines_from_state("WAITING MACHINE ONLINE")
-            #### on verify si il y a des machines online dans cet ensemble
-            for machine in machines_waitting_online:
-                #machine WAITING MACHINE ONLINE presente ?
+                             type='deploy',
+                             sessionname=machine['sessionid'],
+                             priority=-1,
+                             action="xmpplog",
+                             why=self.boundjid.bare,
+                             module="Deployment | Start | Creation",
+                             date=None,
+                             fromuser=machine['login'])
+            msglog = []
+            # We search for all the machines in the "WAITING MACHINE ONLINE" status
+            machines_waiting_online = XmppMasterDatabase().search_machines_from_state("WAITING MACHINE ONLINE")
+            # We verify if the is online machines in the list.
+            for machine in machines_waiting_online:
                 data = json.loads(machine['result'])
                 if XmppMasterDatabase().getPresenceuuid(machine['inventoryuuid']):
-                    hostnamemachine=machine['jidmachine'].split('@')[0][:-4]
-                    msg="Machine %s online. Starting deployment"%hostnamemachine
+                    machine_hostname=machine['jidmachine'].split('@')[0][:-4]
+                    msg="Machine %s online. Starting deployment" % machine_hostname
                     self.xmpplog(msg,
-                                type='deploy',
-                                sessionname=machine['sessionid'],
-                                priority=-1,
-                                action="xmpplog",
-                                why=self.boundjid.bare,
-                                module="Deployment | Start | Creation",
-                                date=None,
-                                fromuser=machine['login'])
+                                 type='deploy',
+                                 sessionname=machine['sessionid'],
+                                 priority=-1,
+                                 action="xmpplog",
+                                 why=self.boundjid.bare,
+                                 module="Deployment | Start | Creation",
+                                 date=None,
+                                 fromuser=machine['login'])
                     XmppMasterDatabase().update_state_deploy(int(machine['id']), "DEPLOYMENT START")
-                    #"relance deployement on machine online"
-                    # il faut verifier qu'il y ai 1 groupe deja en syncthing.alors seulement on peut decoder de l'incorporer
+                    # We restart the deploiement on online machines.
+                    # We need to check if we already have a syncthing group. If so we can decide to add it.
                     if 'grp' in data['advanced'] and data['advanced']['grp'] is not None and \
                         'syncthing' in data['advanced'] and \
                             data['advanced']['syncthing'] == 1 and \
                                 XmppMasterDatabase().nbsyncthingdeploy(machine['group_uuid'],
                                                                         machine['command']) > 2:
-                        msg =  "Starting peer deployment on machine %s" % machine['jidmachine']
+                        msg = "Starting peer deployment on machine %s" % machine['jidmachine']
                         self.xmpplog(msg,
-                                    type='deploy',
-                                    sessionname=machine['sessionid'],
-                                    priority=-1,
-                                    action="xmpplog",
-                                    why=self.boundjid.bare,
-                                    module="Deployment | Start | Creation",
-                                    date=None,
+                                     type='deploy',
+                                     sessionname=machine['sessionid'],
+                                     priority=-1,
+                                     action="xmpplog",
+                                     why=self.boundjid.bare,
+                                     module="Deployment | Start | Creation",
+                                     date=None,
                                     fromuser=data['login'])
                         XmppMasterDatabase().updatedeploytosyncthing(machine['sessionid'])
                         # call plugin master syncthing
-                        ###initialisation deployement syncthing
+                        # initialisation deployement syncthing
                         self.callpluginsubstitute("deploysyncthing",
                                                     data,
                                                     sessionid = machine['sessionid'])
@@ -702,40 +706,40 @@ class MUCBot(sleekxmpp.ClientXMPP):
                                                                                 machine['jid_relay']))
 
                         command = {'action': "applicationdeploymentjson",
-                                'base64': False,
-                                'sessionid': machine['sessionid'],
-                                'data': data}
+                                   'base64': False,
+                                   'sessionid': machine['sessionid'],
+                                   'data': data}
 
                         self.send_message(mto= machine['jid_relay'],
-                                        mbody=json.dumps(command),
-                                        mtype='chat')
+                                          mbody=json.dumps(command),
+                                          mtype='chat')
                         for logmsg in msglog:
                             self.xmpplog(logmsg,
-                                        type='deploy',
-                                        sessionname=machine['sessionid'],
-                                        priority=-1,
-                                        action="xmpplog",
-                                        why=self.boundjid.bare,
-                                        module="Deployment | Start | Creation",
-                                        date=None,
-                                        fromuser=machine['login'])
-                        msglog=[]
+                                         type='deploy',
+                                         sessionname=machine['sessionid'],
+                                         priority=-1,
+                                         action="xmpplog",
+                                         why=self.boundjid.bare,
+                                         module="Deployment | Start | Creation",
+                                         date=None,
+                                         fromuser=machine['login'])
+                        msglog = []
                         if 'syncthing' in data['advanced'] and \
                             data['advanced']['syncthing'] == 1:
                             self.xmpplog("<span class='log_warn'>There are not enough machines " \
                                             "to deploy in peer mode</span>",
-                                    type='deploy',
-                                    sessionname=machine['sessionid'],
-                                    priority=-1,
-                                    action="xmpplog",
-                                    why=self.boundjid.bare,
-                                    module="Deployment | Start | Creation",
-                                    date=None,
-                                    fromuser=data['login'])
+                                         type='deploy',
+                                         sessionname=machine['sessionid'],
+                                         priority=-1,
+                                         action="xmpplog",
+                                         why=self.boundjid.bare,
+                                         module="Deployment | Start | Creation",
+                                         date=None,
+                                         fromuser=data['login'])
         except Exception:
-            logger.error("%s"%(traceback.format_exc()))
+            logger.error("%s" % (traceback.format_exc()))
         finally:
-            #send wols
+            # Send wols
             wol_set.discard("")
             if len(wol_set):
                 self._sendwolgroup(wol_set)
@@ -953,13 +957,6 @@ class MUCBot(sleekxmpp.ClientXMPP):
             file_put_contents("/tmp/Execution_time_plugin.txt",
                               "%s | %s \n" %(str(datetime.now()),
                               obj['result'] ))
-        #self.get_roster()
-        #try:
-            #self.get_roster()
-        #except IqError as err:
-            #print('Error: %s' % err.iq['error']['condition'])
-        #except IqTimeout:
-            #print('Error: Request timed out')
         self.send_presence()
         chatroomjoin = [self.config.confjidchatroom]
         for chatroom in chatroomjoin:


### PR DESCRIPTION
In some circumstances some deploiements can be stalled. The reasons are
multiples but some can be:
 -> The machine goes offline then online
 -> The machine changes its ARS
 -> etc.

Now if we get with some status for a long time ( status of non working
deploiements ) we restart the deploiement automatically.