### PR TITLE
(imaging) Add iPXE support

### DIFF
--- a/services/contrib/imaging/sql/schema-022.sql
+++ b/services/contrib/imaging/sql/schema-022.sql
@@ -1,0 +1,81 @@
+--
+-- (c) 2022 Siveo, http://siveo.net/
+--
+-- $Id$
+--
+-- This file is part of Pulse 2, http://siveo.net
+--
+-- Pulse 2 is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+--
+-- Pulse 2 is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with Pulse 2; if not, write to the Free Software
+-- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+-- MA 02110-1301, USA.
+
+START TRANSACTION;
+
+-- Add login column to Entity table
+ALTER TABLE Entity ADD COLUMN pxe_login VARCHAR(255) NOT NULL DEFAULT "" AFTER uuid;
+
+-- --------------------------------
+-- Updating current BootServices --
+-- --------------------------------
+-- continue
+-- continue action is special, because it is used both in protected menu and normal menu
+-- if the login failed, load ${loaded-menu}. If MENU is always loaded, the password is not checked and we have access to the main menu
+UPDATE BootService SET value="set url_path http://${next-server}/downloads/davos/
+iseq ${platform} pcbios && sanboot --no-describe --drive 0x80 ||
+imgfetch ${next-server}/downloads/davos/refind.conf
+iseq ${buildarch} x86_64 && chain -ar ${url_path}refind_x64.efi ||
+iseq ${buildarch} i386 && chain -ar ${url_path}refind_ia32.efi ||
+iseq ${buildarch} arm32 && chain -ar ${url_path}refind_aa32.efi ||
+iseq ${buildarch} arm64 && chain -ar ${url_path}refind_aa64.efi ||
+goto MENU" WHERE default_name = 'continue';
+
+-- register
+UPDATE BootService SET value="set url_path http://${next-server}/downloads/##PULSE2_DISKLESS_DIR##/
+set kernel_args boot=live config noswap edd=on nomodeset raid=noautodetect fetch=${url_path}fs.squashfs davos_action=REGISTER  dump_path=##PULSE2_INVENTORIES_DIR## timereboot=##PULSE2_PXE_TIME_REBOOT## initrd=##PULSE2_DISKLESS_INITRD##
+kernel ${url_path}##PULSE2_DISKLESS_KERNEL## ${kernel_args}
+initrd ${url_path}initrd.img
+boot || goto MENU" WHERE default_name = 'register';
+-- reboot
+UPDATE BootService SET value="reboot || goto MENU" WHERE default_name = 'reboot';
+
+-- poweroff
+UPDATE BootService SET value="poweroff || goto MENU" WHERE default_name = 'poweroff';
+
+-- backup
+UPDATE BootService SET value="set url_path http://${next-server}/downloads/##PULSE2_DISKLESS_DIR##/
+set kernel_args boot=live config noswap edd=on nomodeset raid=noautodetect fetch=${url_path}fs.squashfs davos_action=SAVE_IMAGE mac=##MACADDRESS##  timereboot=2 initrd=initrd.img
+kernel ${url_path}vmlinuz ${kernel_args}
+initrd ${url_path}initrd.img
+boot || goto MENU" WHERE default_name = 'backup';
+
+-- gparted
+UPDATE BootService SET value="set url_path http://${next-server}/downloads/##PULSE2_TOOLS_DIR##/gparted/
+kernel ${url_path}vmlinuz boot=live config components union=overlay username=user noswap noeject ip= vga=788 fetch=${url_path}filesystem.squashfs
+initrd ${url_path}initrd.img
+boot || goto MENU" WHERE default_name = 'gparted';
+
+-- diskless
+UPDATE BootService SET value="set url_path http://${next-server}/downloads/##PULSE2_TOOLS_DIR##/avg/
+kernel ${url_path}vmlinuz max_loop=255 vga=791 video=vesafb init=linuxrc
+initrd ${url_path}initrd.lzm
+boot || goto MENU" WHERE default_name = 'avg';
+
+UPDATE BootService SET value="set url_path http://${next-server}/downloads/##PULSE2_DISKLESS_DIR##/
+set kernel_args boot=live config noswap edd=on nomodeset raid=noautodetect fetch=${url_path}fs.squashfs davos_debug=i timereboot=##PULSE2_PXE_TIME_REBOOT## initrd=##PULSE2_DISKLESS_INITRD##
+kernel ${url_path}##PULSE2_DISKLESS_KERNEL## ${kernel_args}
+initrd ${url_path}##PULSE2_DISKLESS_INITRD## " WHERE default_name = 'diskless';
+
+UPDATE version set Number = 22;
+
+COMMIT;

--- a/services/mmc/plugins/imaging/functions.py
+++ b/services/mmc/plugins/imaging/functions.py
@@ -2,10 +2,11 @@
 #
 # (c) 2004-2007 Linbox / Free&ALter Soft, http://linbox.com
 # (c) 2007 Mandriva, http://www.mandriva.com/
+# (c) 2022 Siveo, http://siveo.net
 #
 # $Id$
 #
-# This file is part of Mandriva Management Console (MMC).
+# This file is part of Management Console (MMC).
 #
 # MMC is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -1744,6 +1745,9 @@ class ImagingRpcProxy(RpcProxyI):
 
     def getClonezillaRestorerParams(self, location_uuid):
         return ImagingDatabase().getClonezillaRestorerParams(location_uuid)
+
+    def getPXELogin(self, location_uuid):
+        return ImagingDatabase().getPXELogin(location_uuid)
 
     def getPXEPasswordHash(self, location_uuid):
         return ImagingDatabase().getPXEPasswordHash(location_uuid)
@@ -3498,6 +3502,7 @@ class ImagingRpcProxy(RpcProxyI):
             return {}
         params = {}
         params['pxe_keymap'] = location.pxe_keymap
+        params['pxe_login'] = location.pxe_login
         params['pxe_password'] = location.pxe_password
         return xmlrpcCleanup(params)
 

--- a/services/pulse2/database/imaging/__init__.py
+++ b/services/pulse2/database/imaging/__init__.py
@@ -2,10 +2,11 @@
 #
 # (c) 2004-2007 Linbox / Free&ALter Soft, http://linbox.com
 # (c) 2007-2010 Mandriva, http://www.mandriva.com/
+# (c) 2022 Siveo, http://siveo.net
 #
 # $Id$
 #
-# This file is part of Pulse 2, http://pulse2.mandriva.org
+# This file is part of Pulse 2, http://siveo.net
 #
 # Pulse 2 is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -3540,6 +3541,12 @@ class ImagingDatabase(DyngroupDatabaseHelper):
         passphrase = '$6$DzmCpUs3$'
         return crypt.crypt(password, passphrase)
 
+    def getPXELogin(self, location_uuid):
+        session = create_session()
+        login = session.query(Entity.pxe_login).filter(Entity.uuid == location_uuid).scalar()
+        session.close()
+        return login
+
     def getPXEPasswordHash(self, location_uuid):
         session = create_session()
         password = session.query(Entity.pxe_password).filter(Entity.uuid == location_uuid).scalar()
@@ -3550,8 +3557,11 @@ class ImagingDatabase(DyngroupDatabaseHelper):
         session = create_session()
         try:
             location = session.query(Entity).filter(Entity.uuid == uuid).one()
+            if 'pxe_login' in params:
+                location.pxe_login = params['pxe_login']
             if 'pxe_password' in params:
-                location.pxe_password = self.__sha512_crypt_password(params['pxe_password'])
+                #location.pxe_password = self.__sha512_crypt_password(params['pxe_password'])
+                location.pxe_password = params['pxe_password']
             if 'pxe_keymap' in params:
                 location.pxe_keymap = params['pxe_keymap']
             elif 'language' in params:

--- a/services/pulse2/package_server/imaging/api/functions.py
+++ b/services/pulse2/package_server/imaging/api/functions.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; -*-
 #
 # (c) 2007-2010 Mandriva, http://www.mandriva.com/
+# (c) 2022 Siveo, http://siveo.net
 #
 # $Id$
 #
-# This file is part of Pulse 2, http://pulse2.mandriva.org
+# This file is part of Pulse 2, http://siveo.net
 #
 # Pulse 2 is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -123,6 +124,7 @@ class Imaging(object):
 
     def refreshPXEParams(self, callback = None, *args, **kw):
         def _success(params):
+            PackageServerConfig().pxe_login = params['pxe_login']
             PackageServerConfig().pxe_password = params['pxe_password']
             PackageServerConfig().pxe_keymap = params['pxe_keymap']
             if callback: callback.__call__(*args, **kw)

--- a/services/pulse2/package_server/imaging/menu.py
+++ b/services/pulse2/package_server/imaging/menu.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; -*-
 #
 # (c) 2009-2010 Mandriva, http://www.mandriva.com/
+# (c) 2022 Siveo, http://siveo.net
 #
 # $Id$
 #
-# This file is part of Pulse 2, http://pulse2.mandriva.org
+# This file is part of Pulse 2, http://siveo.net
 #
 # Pulse 2 is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,6 +34,7 @@ import stat
 import pulse2.utils
 import pulse2.package_server.imaging.api.functions
 from pulse2.package_server.config import P2PServerCP as PackageServerConfig
+import unicodedata
 
 
 def isMenuStructure(menu):
@@ -233,7 +235,7 @@ class ImagingMenu:
                 'nosplash',
                 'noprompt',
                 'vga=788',
-                'fetch=tftp://%s/%s/fs.squashfs' % (PackageServerConfig().public_ip, self.config.imaging_api['diskless_folder'])]
+                'fetch=${url_path}fs.squashfs']
 
             # If we have a mac, we put it in kernel params
             if macaddress is not None:
@@ -262,6 +264,8 @@ class ImagingMenu:
         replacements = [
             ('##PULSE2_LANG##', PackageServerConfig().pxe_keymap, 'global'),
             ('##PULSE2_PUBLIC_IP##', PackageServerConfig().public_ip, 'global'),
+            ('##PXE_LOGIN##', PackageServerConfig().pxe_login, 'global'),
+            ('##PXE_PASSWORD##', PackageServerConfig().pxe_password, 'global'),
             ('##PULSE2_BOOTLOADER_DIR##', self.config.imaging_api['bootloader_folder'], 'global'),
             ('##PULSE2_TOOLS_DIR##', self.config.imaging_api['tools_folder'], 'global'),
             ('##PULSE2_BOOTSPLASH_FILE##', self.config.imaging_api['bootsplash_file'], 'global'),
@@ -290,6 +294,11 @@ class ImagingMenu:
                 ('##MAC##',
                  pulse2.utils.reduceMACAddress(self.mac),
                  'global'))
+            # To get normal macaddress aa:bb:cc ... instead of aa-bb-cc ...
+            replacements.append(
+                ('##MACADDRESS##',
+                self.mac,
+                'global'))
 
         output = string
         for replacement in replacements:
@@ -329,6 +338,113 @@ class ImagingMenu:
         for c in s:
             ret.append(_reptable.get(ord(c) ,c))
         return u"".join(ret)
+
+    def buildMenuIpxe(self):
+        """
+        @return: the SYSLINUX boot menu as a string encoded using CP-437
+        @rtype: str
+        """
+
+        if self.hostname != "":
+            menu_title = 'item --gap Host %s registered!\n'%self.hostname
+        else:
+            menu_title = 'item --gap Host is NOT registered!\n'
+
+        # takes global items, one by one
+        buf = '#!ipxe\n'
+        if PackageServerConfig().pxe_password != '':
+            buf += 'set loaded-menu MAIN\n'
+        else:
+            buf += 'set loaded-menu MENU\n'
+
+        buf += 'cpuid --ext 29 && set arch x86_64 || set arch i386\n'
+        buf += 'goto get_console\n'
+        buf += ':console_set\n'
+        buf += 'colour --rgb 0x00567a 1 ||\n'
+        buf += 'colour --rgb 0x00567a 2 ||\n'
+        buf += 'colour --rgb 0x00567a 4 ||\n'
+        buf += 'cpair --foreground 7 --background 2 2 ||\n'
+        buf += 'goto ${loaded-menu}\n'
+        buf += ':alt_console\n'
+        buf += 'cpair --background 0 1 ||\n'
+        buf += 'cpair --background 1 2 ||\n'
+        buf += 'goto ${loaded-menu}\n'
+        buf += ':get_console\n'
+        buf += 'console --picture http://${next-server}/downloads/davos/ipxe.png --left 100 --right 80 && goto console_set || goto alt_console\n'
+        buf += ':MAIN\n'
+        buf += 'menu\n'
+        buf += 'colour --rgb 0xff0000 0 ||\n'
+        buf += 'cpair --foreground 1 1 ||\n'
+        buf += 'cpair --foreground 0 3 ||\n'
+        buf += 'cpair --foreground 4 4 ||\n'
+        buf += menu_title
+        buf += 'item --gap -- -------------------------------------\n'
+        indices = self.menuitems.keys()
+        indices.sort()
+        has_continue_bootservice = False
+        for i in indices:
+            if self.menuitems[i].label != "continue":
+                continue
+            else:
+                has_continue_bootservice = True
+                if hasattr(self.menuitems[i], 'value'):
+                    buf += 'item %s %s\n'%(self._applyReplacement(self.menuitems[i].label), self.menuitems[i].menulabel)
+                else:
+                    buf += 'item %s %s\n'%(self._applyReplacement(self.menuitems[i].label), self.menuitems[i].label)
+                break
+        buf += 'item protected Password\n'
+        if has_continue_bootservice:
+            buf += 'choose --default continue --timeout %s target && goto ${target}\n'% (int(self.timeout) * 1000)
+        else:
+            buf += 'choose --default protected --timeout %s target && goto ${target}\n'% (int(self.timeout) * 1000)
+        buf += ':MENU\n'
+        buf += 'menu\n'
+        buf += 'colour --rgb 0xff0000 0 ||\n'
+        buf += 'cpair --foreground 1 1 ||\n'
+        buf += 'cpair --foreground 0 3 ||\n'
+        buf += 'cpair --foreground 4 4 ||\n'
+        buf += menu_title
+        buf += 'item --gap -- -------------------------------------\n'
+
+        # write items
+        indices = self.menuitems.keys()
+        indices.sort()
+        for i in indices:
+            if hasattr(self.menuitems[i], 'value'):
+                output = 'item %s %s\n'%(self._applyReplacement(self.menuitems[i].label), self.menuitems[i].menulabel)
+            else:
+                output = 'item %s %s\n'%(self._applyReplacement(self.menuitems[i].label), self.menuitems[i].label)
+            buf += output
+        # the menu default item
+        buf += 'choose --default %s ' % self.default_item
+
+        # the menu timeout : warning, 0 means "do not wait !"
+        if self.timeout == '0':
+            buf += '--timeout 1000 '
+        else:
+            buf += '--timeout %d ' % (int(self.timeout) * 1000)
+        buf += 'target && goto ${target}\n'
+        buf += ':protected\n'
+        buf += 'login || goto ${loaded-menu}\n'
+        buf += 'iseq ${username} %s && iseq ${password} %s && set loaded-menu MENU || set loaded-menu MAIN\n'%(self._applyReplacement('##PXE_LOGIN##'),self._applyReplacement('##PXE_PASSWORD##'))
+        buf += 'goto ${loaded-menu}\n'
+
+        for i in indices:
+            if hasattr(self.menuitems[i], 'value'):
+                # the item represents a bootservice objet
+                buf+= ':%s\n%s\n'%(self._applyReplacement(self.menuitems[i].label), self._applyReplacement(self.menuitems[i].value))
+            else:
+                # the item represents an imagingimageitem object
+                buf+= ':%s\n%s\n'%(self._applyReplacement(self.menuitems[i]._applyReplacement(self.menuitems[i].label)), self._applyReplacement(self.menuitems[i]._applyReplacement(self.menuitems[i].CMDLINE)))
+        assert(type(buf) == unicode)
+        # Clean brazilian characters who are not compatible
+        # with MS-DOS encoding by delete accent marks
+        buf = self.delete_diacritics(buf)
+        # normalize chars before encoding to cp437
+        buf = ''.join(char for char in unicodedata.normalize('NFD', buf) if unicodedata.category(char) != 'Mn')
+        # Encode menu using code page 437 (MS-DOS) encoding
+        buf = buf.encode('cp437')
+        return buf
 
     def buildMenu(self):
         """
@@ -410,7 +526,7 @@ class ImagingMenu:
 
         def _write(self):
             try:
-                buf = self.buildMenu()
+                buf = self.buildMenuIpxe()
             except Exception, e:
                 logging.getLogger().error(str(e))
 
@@ -778,9 +894,11 @@ class ImagingImageItem(ImagingItem):
 
         # Davos imaging client case
         if PackageServerConfig().imaging_api['diskless_folder'] == "davos":
-            self.CMDLINE = u"kernel ##PULSE2_NETDEVICE##/##PULSE2_DISKLESS_DIR##/##PULSE2_DISKLESS_KERNEL## ##PULSE2_KERNEL_OPTS## ##PULSE2_DISKLESS_OPTS## image_uuid=##PULSE2_IMAGE_UUID## davos_action=RESTORE_IMAGE ##PULSE2_DAVOS_OPTS##\ninitrd ##PULSE2_NETDEVICE##/##PULSE2_DISKLESS_DIR##/##PULSE2_DISKLESS_INITRD##\n"
-            self.CMDLINE = u"kernel ../##PULSE2_DISKLESS_DIR##/##PULSE2_DISKLESS_KERNEL## ##PULSE2_KERNEL_OPTS## ##PULSE2_DISKLESS_OPTS## image_uuid=##PULSE2_IMAGE_UUID## davos_action=RESTORE_IMAGE ##PULSE2_DAVOS_OPTS##\ninitrd ../##PULSE2_DISKLESS_DIR##/##PULSE2_DISKLESS_INITRD##\n"
-
+            self.CMDLINE = "set url_path http://${next-server}/downloads/##PULSE2_DISKLESS_DIR##/\n"
+            self.CMDLINE += u"set kernel_args ##PULSE2_KERNEL_OPTS## davos_action=RESTORE_IMAGE image_uuid=##PULSE2_IMAGE_UUID## initrd=##PULSE2_DISKLESS_INITRD##\n"
+            self.CMDLINE += u"kernel ${url_path}vmlinuz ${kernel_args}\n"
+            self.CMDLINE += u"initrd ${url_path}##PULSE2_DISKLESS_INITRD##\n"
+            self.CMDLINE += u"boot || goto MENU\n"
 
     def getEntry(self, network = True):
         """

--- a/services/pulse2/utils.py
+++ b/services/pulse2/utils.py
@@ -420,7 +420,7 @@ def normalizeMACAddressForPXELINUX(mac):
     """
     assert isMACAddress(mac)
     macaddress = '-'.join(map(lambda (x, y): x + y, zip(reduceMACAddress(mac)[0:11:2], reduceMACAddress(mac)[1:12:2]))) # any questions ?
-    return '01-' + macaddress.lower()
+    return macaddress.lower()
 
 
 def macToNode(mac):

--- a/web/modules/imaging/includes/xmlrpc.inc.php
+++ b/web/modules/imaging/includes/xmlrpc.inc.php
@@ -3,11 +3,11 @@
 /**
  * (c) 2004-2007 Linbox / Free&ALter Soft, http://linbox.com
  * (c) 2007-2009 Mandriva, http://www.mandriva.com
- * (c) 2015 Siveo, http://http://www.siveo.net
+ * (c) 2015-2022 Siveo, http://http://www.siveo.net
  *
  * $Id$
  *
- * This file is part of Mandriva Management Console (MMC).
+ * This file is part of Management Console (MMC).
  *
  * MMC is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -543,6 +543,10 @@ function xmlrpc_doesLocationHasImagingServer($location) {
 
 function xmlrpc_getImagingServerConfig($location) {
     return xmlCall("imaging.getImagingServerConfig", array($location));
+}
+
+function xmlrpc_getPXELogin($location){
+  return xmlCall("imaging.getPXELogin", [$location]);
 }
 
 function xmlrpc_getPXEPasswordHash($location) {

--- a/web/modules/imaging/manage/ajaxConfiguration.php
+++ b/web/modules/imaging/manage/ajaxConfiguration.php
@@ -3,10 +3,11 @@
 /*
  * (c) 2004-2007 Linbox / Free&ALter Soft, http://linbox.com
  * (c) 2007-2010 Mandriva, http://www.mandriva.com
+ * (c) 2022 Siveo, http://siveo.net
  *
  * $Id$
  *
- * This file is part of Mandriva Management Console (MMC).
+ * This file is part of Management Console (MMC).
  *
  * MMC is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -59,6 +60,8 @@ $f->add(
         new TrFormElement(_T("Menu language", "imaging"), $language)
 );
 
+$pxe_login_label = _T("PXE Login", "imaging");
+$pxe_login_label_desc = _T('Leave this field empty to unset PXE Password', 'imaging');
 $pxe_password_label = _T('PXE Password', 'imaging');
 $pxe_password_label_desc = _T('Leave this field empty to unset PXE Password', 'imaging');
 $pxe_password_label = <<<EOS
@@ -70,6 +73,10 @@ $pxe_password_label = <<<EOS
 
 </a>
 EOS;
+
+$f->add(
+        new TrFormElement($pxe_login_label, new InputTpl('pxe_login')), array("value" => xmlrpc_getPXELogin($location) == '' ? '' : xmlrpc_getPXELogin($location))
+);
 
 $f->add(
         new TrFormElement($pxe_password_label, new PasswordTpl('pxe_password')), array("value" => xmlrpc_getPXEPasswordHash($location) == '' ? '' : '.......')
@@ -94,7 +101,7 @@ $f->add(
         new TrFormElement(_T('Default menu label', 'imaging'), new InputTpl("default_m_label")), array("value" => $default_menu['default_name'])
 );
 $f->add(
-        new TrFormElement(_T('Default menu timeout', 'imaging'), new InputTpl("default_m_timeout")), array("value" => $default_menu['timeout'])
+        new TrFormElement(_T('Default menu timeout', 'imaging')." (s.)", new InputTpl("default_m_timeout")), array("value" => $default_menu['timeout'])
 );
 if ($default_menu["hidden_menu"]) {
     $hidden_menu_value = 'CHECKED';

--- a/web/modules/imaging/manage/save_configuration.php
+++ b/web/modules/imaging/manage/save_configuration.php
@@ -3,11 +3,11 @@
 /*
  * (c) 2004-2007 Linbox / Free&ALter Soft, http://linbox.com
  * (c) 2007-2009 Mandriva, http://www.mandriva.com
- * (c) 2017 Siveo, http://http://www.siveo.net
+ * (c) 2017-2022 Siveo, http://http://www.siveo.net
  *
  * $Id$
  *
- * This file is part of Mandriva Management Console (MMC).
+ * This file is part of Management Console (MMC).
  *
  * MMC is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -55,6 +55,7 @@ if (xmlrpc_doesLocationHasImagingServer($location)) {
         $params['background_uri'] = $_POST['boot_xpm'];
         $params['message'] = $_POST['boot_msg'];
         $params['language'] = $_POST['language'];
+        $params['pxe_login'] = $_POST['pxe_login'];
         if ($_POST['pxe_password'] != $_POST['old_pxe_password'])
             $params['pxe_password'] = $_POST['pxe_password'];
         $params['clonezilla_saver_params'] = $_POST['clonezilla_saver_params'];


### PR DESCRIPTION
Change pulse to use iPXE instead of old PXELINUX.
https://ipxe.org/

We are now able to use the http protocol to download the fs.squashfs
file.

The change to ipxe allow to support new hardware.

We also use rEFInd to allow to boot on UEFI disks ( when booting on the
disk ).