### PR TITLE
(glpi 9.5) Fix crash with some incomplete inventories

### DIFF
--- a/services/mmc/plugins/glpi/database_95.py
+++ b/services/mmc/plugins/glpi/database_95.py
@@ -5470,8 +5470,12 @@ class Glpi95(DyngroupDatabaseHelper):
                 machine['os'] = ' '.join(machine['os'])
             elif machine['os'].startswith('Ubuntu'):
                 machine['os'] = 'Ubuntu'
-                # We want just the XX.yy version number
-                machine['version'] = machine['version'].split(" ")[0].split(".")
+                if machine['version'] is not None:
+                    # We want just the XX.yy version number
+                    machine['version'] = machine['version'].split(" ")[0].split(".")
+                else:
+                    machine['version'] = "00.00"
+
                 if len(machine['version']) >= 2:
                     machine['version'] = machine['version'][0:2]
                 machine['version'] = '.'.join(machine['version'])


### PR DESCRIPTION
It can happen that some versions ( only seen with ubuntu for the moment
) are missing in Glpi.

In consequence machine['version'] returns None.

I added a workaroung, and now if machine['version'] is equal to None, we
give a fake version 00.00.

It allow to fix the crash and should make simpler to detect uncomplete
inventories