### PR TITLE
[kiosk] some chars in package name are interpreted as regex operator

### DIFF
--- a/services/mmc/plugins/kiosk/__init__.py
+++ b/services/mmc/plugins/kiosk/__init__.py
@@ -351,7 +351,7 @@ def __search_software_in_glpi(list_software_glpi, packageprofile, structuredatak
                                 'description': packageprofile[2],
                                 "version" : packageprofile[3]
                                }
-    patternname = re.compile("(?i)" + packageprofile[0])
+    patternname = re.compile("(?i)" + packageprofile[0].replace('+', '\+').replace('*', '\*'))
     for soft_glpi in list_software_glpi:
         #TODO
         # Into the pulse package provide Vendor information for the software name


### PR DESCRIPTION
For example the '++' in 'Notepad++' will be interpreted as regex operator instead of regular string. It generates a traceback