### PR TITLE
[AUDIT] next_launch_date parameter generates an error on xmlrpc

### DIFF
--- a/services/pulse2/database/msc/__init__.py
+++ b/services/pulse2/database/msc/__init__.py
@@ -2310,10 +2310,10 @@ class MscDatabase(DatabaseHelper):
             t= {    "fk_target" : x[0],
                     "startdate" : x[1].strftime('%Y-%m-%d %H:%M:%S'),
                     "enddate" : x[2].strftime('%Y-%m-%d %H:%M:%S'),
-                    "next_launch_date" : x[3].strftime('%Y-%m-%d %H:%M:%S'),
+                    "next_launch_date" : x[3].strftime('%Y-%m-%d %H:%M:%S') if x[3] is not None else "",
                     "start_dateunixtime" : time.mktime(x[1].timetuple()),
                     "end_dateunixtime" :time.mktime(x[2].timetuple()),
-                    "next_launch_dateunixtime" :time.mktime(x[3].timetuple())
+                    "next_launch_dateunixtime" :time.mktime(x[3].timetuple()) if x[3] is not None else ""
             }
             ret.append(t)
         return ret


### PR DESCRIPTION
xmlrpc is not set to send None values so the next_launch_date parameter generates a traceback if its value is None