### PR TITLE
[FIX CDN] Fix creation hash suffix error

### DIFF
--- a/services/mmc/plugins/pkgs/__init__.py
+++ b/services/mmc/plugins/pkgs/__init__.py
@@ -439,7 +439,7 @@ def generate_hash(path, package_id):
                 file_block = _file.read(BLOCK_SIZE) # Read the next block from the file
 
         try:
-            with open(dest + "/" + file_package + ".hash", 'wb') as _file:
+            with open((os.path.join(dest, file_package)) + ".hash", 'wb') as _file:
                 _file.write(file_hash.hexdigest())
         except:
             logger.debug("The 'docs' directory does not exist")


### PR DESCRIPTION
When we create hash for every file in package in case of CDN deployment, new file be created with 2 suffix ".hash" Example : conf.json.hash.hash
Now, create file with only one ".hash"
Example : conf.json.hash
If "filename.hash" already exist, replace it.